### PR TITLE
feat(ui): phase 2 UI redesign for welcome, auth, and dashboard pages

### DIFF
--- a/lifelink-app/public/css/ui-components.css
+++ b/lifelink-app/public/css/ui-components.css
@@ -21,6 +21,14 @@
     border-color: rgba(3, 105, 161, 0.18);
 }
 
+.ui-card--shell {
+    padding: 22px;
+    border-radius: 28px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 251, 253, 0.92));
+    box-shadow: var(--ui-shadow-lg);
+}
+
 .ui-section {
     padding: 18px;
     background: var(--ui-surface);
@@ -64,7 +72,7 @@
     font-weight: 700;
     text-decoration: none;
     cursor: pointer;
-    transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+    transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .ui-btn:hover,
@@ -80,6 +88,7 @@
 .path-link:hover,
 .ghost-link:hover {
     transform: translateY(-1px);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
 
 .ui-btn--primary,
@@ -122,14 +131,31 @@
 .mini-link,
 .path-link,
 .ghost-link {
-    background: rgba(255, 255, 255, 0.78);
+    background: rgba(255, 255, 255, 0.84);
     color: var(--ui-text);
-    border-color: var(--ui-border);
+    border-color: var(--ui-border-soft);
 }
 
 .ui-btn--ghost {
     background: transparent;
     color: var(--ui-text-muted);
+}
+
+.app-shell__button {
+    background: linear-gradient(135deg, var(--ui-primary), var(--ui-primary-strong));
+    border-color: transparent;
+    color: #fff;
+    box-shadow: 0 14px 26px rgba(3, 105, 161, 0.18);
+}
+
+.app-shell__button:hover {
+    background: linear-gradient(135deg, var(--ui-primary-strong), var(--ui-primary));
+}
+
+.app-shell__chip:hover {
+    border-color: rgba(3, 105, 161, 0.18);
+    background: rgba(224, 242, 254, 0.72);
+    color: var(--ui-primary-strong);
 }
 
 .ui-btn--danger,
@@ -186,6 +212,13 @@
 
 .app-shell__sidebar-card + .app-shell__sidebar-card {
     margin-top: 12px;
+}
+
+.app-shell__sidebar-card {
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.76);
+    border: 1px solid var(--ui-border-soft);
+    border-radius: 18px;
 }
 
 .app-shell__sidebar-card strong,
@@ -258,7 +291,7 @@
     display: grid;
     gap: 12px;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    padding: 16px;
+    padding: 16px 18px;
     background: var(--ui-surface);
     border: 1px solid var(--ui-border);
     border-radius: 18px;
@@ -270,8 +303,9 @@
 .it-table-wrap {
     overflow: auto;
     border: 1px solid var(--ui-border);
-    border-radius: 14px;
-    background: rgba(255, 255, 255, 0.92);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
 .ui-table,
@@ -288,7 +322,7 @@
 .nurse-table td,
 .it-table th,
 .it-table td {
-    padding: 9px 10px;
+    padding: 11px 12px;
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
     text-align: left;
     white-space: nowrap;
@@ -297,11 +331,17 @@
 .ui-table th,
 .nurse-table th,
 .it-table th {
-    background: rgba(248, 250, 252, 0.95);
+    background: rgba(248, 250, 252, 0.98);
     color: var(--ui-text-muted);
     font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
+}
+
+.ui-table tr:hover,
+.nurse-table tr:hover,
+.it-table tr:hover {
+    background: rgba(248, 250, 252, 0.82);
 }
 
 .ui-table tr.is-selected,
@@ -394,17 +434,94 @@
     font-size: 0.92rem;
 }
 
-.ll-debug-marker {
-    display: inline-flex;
-    align-items: center;
-    margin-top: 12px;
-    padding: 6px 10px;
-    border: 1px dashed rgba(194, 65, 12, 0.35);
-    border-radius: 999px;
-    background: rgba(255, 237, 213, 0.9);
-    color: #9a3412;
-    font-size: 0.72rem;
-    font-weight: 800;
-    letter-spacing: 0.04em;
+.welcome-proof,
+.welcome-metrics,
+.auth-intro__trust {
+    display: grid;
+    gap: 12px;
+}
+
+.welcome-proof {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin-top: 20px;
+}
+
+.welcome-proof__item,
+.welcome-highlight,
+.welcome-metric,
+.welcome-module-card,
+.auth-trust-card,
+.auth-links,
+.auth-card__header,
+.auth-session-card,
+.workspace-primary__copy {
+    display: grid;
+    gap: 8px;
+}
+
+.welcome-proof__item,
+.welcome-highlight,
+.auth-trust-card,
+.welcome-metric {
+    padding: 16px;
+    border: 1px solid var(--ui-border-soft);
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.82);
+}
+
+.welcome-highlight__label {
+    font-size: 0.75rem;
     text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 800;
+    color: var(--ui-primary);
+}
+
+.welcome-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.welcome-metric strong {
+    font-size: 1.8rem;
+    line-height: 1;
+}
+
+.welcome-metric span,
+.welcome-proof__item span,
+.welcome-highlight p,
+.auth-trust-card span {
+    color: var(--ui-text-muted);
+}
+
+.welcome-module-card {
+    min-height: 100%;
+}
+
+.welcome-entry-card--support {
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(240, 249, 255, 0.88));
+}
+
+.auth-shell__topbar,
+.auth-shell__crumbs {
+    width: 100%;
+}
+
+.auth-intro__panel > p,
+.auth-card__header p {
+    margin: 10px 0 0;
+}
+
+.auth-message {
+    margin-top: 22px;
+}
+
+.workspace-shortcuts .hub-grid {
+    margin-top: 10px;
+}
+
+@media (max-width: 780px) {
+    .welcome-metrics {
+        grid-template-columns: 1fr;
+    }
 }

--- a/lifelink-app/public/css/ui-dashboard.css
+++ b/lifelink-app/public/css/ui-dashboard.css
@@ -4,17 +4,18 @@
 
 .ll-section-nav {
     position: sticky;
-    top: 10px;
+    top: 14px;
     z-index: 8;
     margin-bottom: var(--ui-space-3);
     display: flex;
     flex-wrap: wrap;
-    gap: var(--ui-space-1);
-    padding: var(--ui-space-1);
-    border: 1px solid var(--ui-border);
-    border-radius: 14px;
-    background: rgba(255, 255, 255, 0.92);
-    box-shadow: var(--ui-shadow-sm);
+    gap: 8px;
+    padding: 10px;
+    border: 1px solid var(--ui-border-soft);
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.88);
+    box-shadow: var(--ui-shadow-md);
+    backdrop-filter: blur(14px);
 }
 
 .ll-section-nav a,
@@ -23,14 +24,15 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 38px;
-    padding: 8px 12px;
-    border-radius: 14px;
+    min-height: 42px;
+    padding: 10px 14px;
+    border-radius: 16px;
     border: 1px solid transparent;
     color: var(--ui-text-muted);
     font-size: 0.9rem;
     font-weight: 700;
     background: rgba(15, 23, 42, 0.04);
+    transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
 }
 
 .ll-section-nav a:hover,
@@ -40,8 +42,40 @@
 .topnav a:hover,
 .topnav .cta {
     color: var(--ui-primary);
-    border-color: rgba(3, 105, 161, 0.18);
-    background: rgba(3, 105, 161, 0.1);
+    border-color: rgba(3, 105, 161, 0.16);
+    background: linear-gradient(135deg, rgba(224, 242, 254, 0.94), rgba(236, 253, 245, 0.82));
+    box-shadow: 0 12px 22px rgba(3, 105, 161, 0.12);
+    transform: translateY(-1px);
+}
+
+.app-shell__nav a {
+    justify-content: flex-start;
+    padding: 12px 14px;
+    background: transparent;
+    border-color: transparent;
+    border-radius: 18px;
+    position: relative;
+}
+
+.app-shell__nav a strong {
+    font-size: 0.94rem;
+    font-weight: 700;
+}
+
+.app-shell__nav a::after {
+    content: "";
+    margin-left: auto;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: transparent;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+}
+
+.app-shell__nav a.is-active::after,
+.app-shell__nav a:hover::after {
+    background: linear-gradient(135deg, var(--ui-primary), var(--ui-secondary));
+    box-shadow: none;
 }
 
 .topnav .cta {
@@ -96,7 +130,7 @@
 .nurse-panel,
 .it-panel,
 .it-card {
-    padding: 16px;
+    padding: 18px;
 }
 
 .nurse-split,
@@ -166,8 +200,8 @@
 .it-chip,
 .hub-card {
     border: 1px solid var(--ui-border);
-    border-radius: 14px;
-    background: rgba(255, 255, 255, 0.9);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.92);
 }
 
 .nurse-stat,
@@ -269,10 +303,11 @@
 }
 
 .bbops-card {
-    padding: 14px;
+    padding: 16px;
     border: 1px solid var(--ui-border);
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.92);
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: var(--ui-shadow-sm);
 }
 
 .bbops-card.is-selected {
@@ -305,7 +340,7 @@
 .bbops-empty {
     padding: 16px;
     border: 1px dashed var(--ui-border-strong);
-    border-radius: 16px;
+    border-radius: 18px;
     color: var(--ui-text-muted);
     background: rgba(248, 250, 252, 0.84);
 }
@@ -318,7 +353,7 @@
     display: block;
     padding: 12px 14px;
     border: 1px solid var(--ui-border);
-    border-radius: 16px;
+    border-radius: 18px;
     background: rgba(255, 255, 255, 0.92);
     color: var(--ui-text);
     text-decoration: none;
@@ -423,6 +458,25 @@
 .hub-card .hub-actions,
 .finder-support {
     margin-top: 10px;
+}
+
+.workspace-shell .hub-block,
+.workspace-shell .hub-card {
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 251, 253, 0.92));
+}
+
+.workspace-hero__main,
+.workspace-hero__side {
+    padding: 18px;
+}
+
+.workspace-primary {
+    margin-top: 2px;
+}
+
+.workspace-primary .hub-primary {
+    min-width: 180px;
 }
 
 @media (max-width: 1120px) {

--- a/lifelink-app/public/css/ui-layout.css
+++ b/lifelink-app/public/css/ui-layout.css
@@ -14,9 +14,9 @@ body {
     color: var(--ui-text);
     font-family: var(--ui-font-body);
     background:
-        radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 24rem),
+        radial-gradient(circle at top left, rgba(59, 130, 246, 0.12), transparent 28rem),
         radial-gradient(circle at top right, rgba(13, 148, 136, 0.12), transparent 24rem),
-        linear-gradient(180deg, #fcfeff 0%, var(--ui-bg) 100%);
+        linear-gradient(180deg, #fcfeff 0%, var(--ui-bg-canvas) 46%, #eef4f8 100%);
 }
 
 a {
@@ -41,12 +41,12 @@ p {
 .app-shell,
 .shell,
 .hub-shell {
-    width: min(1500px, calc(100% - 32px));
+    width: min(var(--ui-shell-max), calc(100% - 32px));
     margin: 0 auto;
 }
 
 .shell {
-    width: min(1280px, calc(100% - 32px));
+    width: min(var(--ui-shell-content-max), calc(100% - 32px));
 }
 
 body > .shell {
@@ -59,7 +59,9 @@ body > .shell {
 }
 
 .app-shell {
-    padding: 16px 0 28px;
+    padding: 20px 0 32px;
+    display: grid;
+    gap: 18px;
 }
 
 .app-shell__topbar,
@@ -73,7 +75,21 @@ body > .shell {
 }
 
 .app-shell__topbar {
-    padding: 10px 0 16px;
+    padding: 16px 18px;
+    border: 1px solid rgba(255, 255, 255, 0.78);
+    border-radius: 24px;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(244, 250, 252, 0.88)),
+        rgba(255, 255, 255, 0.92);
+    box-shadow: var(--ui-shadow-md);
+    backdrop-filter: blur(18px);
+}
+
+.app-shell__topbar-main {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    min-width: 0;
 }
 
 .topbar-inner {
@@ -99,14 +115,16 @@ body > .shell {
 .app-shell__mark,
 .brand-mark,
 .hub-mark {
-    width: 48px;
-    height: 48px;
+    width: 52px;
+    height: 52px;
     display: grid;
     place-items: center;
-    border-radius: 16px;
+    border-radius: 18px;
     color: #fff;
     font-weight: 800;
-    background: linear-gradient(135deg, var(--ui-primary), var(--ui-secondary));
+    background:
+        radial-gradient(circle at 28% 24%, rgba(255, 255, 255, 0.28), transparent 42%),
+        linear-gradient(135deg, var(--ui-primary), var(--ui-secondary));
     box-shadow: 0 18px 28px rgba(3, 105, 161, 0.22);
 }
 
@@ -121,7 +139,12 @@ body > .shell {
 .brand-copy strong,
 .hub-brand strong {
     display: block;
-    font-size: 1.05rem;
+    font-size: 1.02rem;
+}
+
+.app-shell__brand-copy {
+    display: grid;
+    gap: 4px;
 }
 
 .app-shell__brand span,
@@ -130,6 +153,34 @@ body > .shell {
 .hub-copy,
 .crumbs {
     color: var(--ui-text-muted);
+}
+
+.app-shell__session-pill {
+    margin-left: auto;
+    min-width: min(100%, 280px);
+    padding: 12px 14px;
+    border: 1px solid var(--ui-border-soft);
+    border-radius: 18px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(240, 249, 255, 0.86));
+    display: grid;
+    gap: 3px;
+}
+
+.app-shell__session-label {
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ui-text-faint);
+}
+
+.app-shell__session-pill strong {
+    font-size: 0.96rem;
+}
+
+.app-shell__session-pill span:last-child {
+    color: var(--ui-text-muted);
+    font-size: 0.86rem;
 }
 
 .crumbs {
@@ -142,20 +193,21 @@ body > .shell {
 .app-shell__hero,
 .hero,
 .panel.hero {
-    border: 1px solid rgba(255, 255, 255, 0.8);
-    border-radius: var(--ui-radius-xl);
+    border: 1px solid rgba(255, 255, 255, 0.84);
+    border-radius: 30px;
     background:
-        radial-gradient(circle at top left, rgba(217, 119, 6, 0.12), transparent 18rem),
-        linear-gradient(150deg, rgba(255, 255, 255, 0.96), rgba(232, 248, 246, 0.84));
-    box-shadow: var(--ui-shadow-lg);
+        radial-gradient(circle at top left, rgba(217, 119, 6, 0.08), transparent 20rem),
+        radial-gradient(circle at top right, rgba(59, 130, 246, 0.08), transparent 22rem),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(236, 246, 249, 0.88));
+    box-shadow: var(--ui-shadow-xl);
 }
 
 .app-shell__hero {
-    padding: var(--ui-space-5);
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 20px;
+    padding: 24px 28px;
+    display: grid;
+    grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+    gap: 24px;
+    align-items: start;
 }
 
 .hero {
@@ -166,7 +218,7 @@ body > .shell {
 }
 
 .app-shell__hero-copy {
-    max-width: 70ch;
+    max-width: 72ch;
 }
 
 .app-shell__eyebrow,
@@ -197,8 +249,9 @@ body > .shell {
 .app-shell__hero h1,
 .hero h1,
 .hub-title {
-    font-size: clamp(1.9rem, 3vw, 3.2rem);
-    line-height: 1.06;
+    font-size: clamp(1.75rem, 2.6vw, 2.7rem);
+    line-height: 1.08;
+    max-width: 22ch;
 }
 
 .app-shell__hero p,
@@ -208,7 +261,11 @@ body > .shell {
 .hub-copy,
 .panel p {
     margin: 12px 0 0;
-    line-height: 1.7;
+    line-height: 1.65;
+}
+
+.app-shell__hero-extra {
+    margin-top: 16px;
 }
 
 .app-shell__hero-meta,
@@ -221,6 +278,7 @@ body > .shell {
 
 .app-shell__hero-meta {
     min-width: 260px;
+    align-content: start;
 }
 
 .app-shell__meta-card,
@@ -234,7 +292,7 @@ body > .shell {
 .hub-rail {
     border: 1px solid var(--ui-border);
     border-radius: var(--ui-radius-lg);
-    background: rgba(255, 255, 255, 0.88);
+    background: var(--ui-surface-elevated);
     box-shadow: var(--ui-shadow-md);
 }
 
@@ -244,7 +302,16 @@ body > .shell {
 .card,
 .finder-panel,
 .anatomy-card {
-    padding: 16px;
+    padding: 16px 18px;
+}
+
+.app-shell__meta-card {
+    display: grid;
+    gap: 5px;
+}
+
+.app-shell__meta-card--identity {
+    background: linear-gradient(180deg, #ffffff, rgba(224, 242, 254, 0.72));
 }
 
 .app-shell__meta-card small,
@@ -265,7 +332,7 @@ body > .shell {
 .app-shell__body,
 .hub-layout {
     grid-template-columns: 280px minmax(0, 1fr);
-    margin-top: 14px;
+    align-items: start;
 }
 
 .layout {
@@ -276,20 +343,45 @@ body > .shell {
 .app-shell__sidebar,
 .app-shell__content {
     border: 1px solid var(--ui-border);
-    border-radius: var(--ui-radius-lg);
+    border-radius: 24px;
     background: rgba(255, 255, 255, 0.84);
     box-shadow: var(--ui-shadow-lg);
 }
 
 .app-shell__sidebar {
-    padding: 14px;
+    padding: 18px 16px;
     align-self: start;
     position: sticky;
-    top: 14px;
+    top: 16px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(246, 250, 252, 0.92));
 }
 
 .app-shell__content {
-    padding: 18px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+.app-shell__sidebar-head {
+    display: grid;
+    gap: 8px;
+    padding: 0 4px 14px;
+}
+
+.app-shell__sidebar-eyebrow {
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ui-text-faint);
+}
+
+.app-shell__sidebar-copy {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.55;
 }
 
 .hub-rail {
@@ -329,8 +421,8 @@ body > .shell {
 
 .app-shell__nav {
     display: grid;
-    gap: 10px;
-    margin-bottom: 14px;
+    gap: 8px;
+    margin-bottom: 16px;
 }
 
 .app-shell__nav a {
@@ -349,10 +441,112 @@ body > .shell {
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
+.topbar--public {
+    background: rgba(248, 251, 253, 0.84);
+}
+
 main {
     padding: 28px 0 40px;
     display: grid;
     gap: 18px;
+}
+
+.welcome-main {
+    gap: 22px;
+}
+
+.welcome-hero,
+.welcome-bands,
+.welcome-entry-grid,
+.auth-layout,
+.workspace-hero {
+    display: grid;
+    gap: 16px;
+}
+
+.welcome-hero {
+    grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+    align-items: stretch;
+}
+
+.welcome-hero__copy,
+.welcome-hero__aside,
+.welcome-band,
+.welcome-entry-card,
+.auth-intro,
+.auth-card,
+.workspace-primary {
+    border: 1px solid var(--ui-border);
+    border-radius: 28px;
+    background: rgba(255, 255, 255, 0.88);
+    box-shadow: var(--ui-shadow-lg);
+}
+
+.welcome-hero__copy,
+.welcome-hero__aside,
+.welcome-entry-card,
+.auth-card,
+.workspace-primary {
+    padding: 24px;
+}
+
+.welcome-hero__copy {
+    background:
+        radial-gradient(circle at top left, rgba(59, 130, 246, 0.16), transparent 24rem),
+        radial-gradient(circle at bottom right, rgba(13, 148, 136, 0.14), transparent 22rem),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.99), rgba(236, 246, 249, 0.92));
+}
+
+.welcome-hero__aside {
+    display: grid;
+    gap: 14px;
+    align-content: space-between;
+    padding: 24px;
+}
+
+.welcome-bands {
+    grid-template-columns: 1.1fr 0.9fr;
+}
+
+.welcome-band {
+    padding: 18px 20px;
+}
+
+.welcome-module-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.welcome-entry-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.auth-layout {
+    grid-template-columns: minmax(320px, 0.84fr) minmax(0, 1.16fr);
+    align-items: start;
+}
+
+.auth-intro {
+    display: grid;
+    gap: 14px;
+    position: sticky;
+    top: 90px;
+}
+
+.workspace-hero {
+    grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+}
+
+.workspace-primary {
+    display: flex;
+    justify-content: space-between;
+    gap: 18px;
+    align-items: center;
+}
+
+.app-shell__content-body {
+    min-height: 100%;
 }
 
 .grid,
@@ -431,14 +625,31 @@ main {
     .hub-rail {
         position: static;
     }
+
+    .app-shell__hero {
+        grid-template-columns: 1fr;
+    }
 }
 
 @media (max-width: 980px) {
     .hero,
     .grid,
     .auth-grid,
-    .finder-shell {
+    .finder-shell,
+    .welcome-hero,
+    .welcome-bands,
+    .auth-layout,
+    .workspace-hero {
         grid-template-columns: 1fr;
+    }
+
+    .auth-intro {
+        position: static;
+    }
+
+    .workspace-primary {
+        flex-direction: column;
+        align-items: flex-start;
     }
 }
 
@@ -454,12 +665,24 @@ main {
     .hub-topbar,
     .topbar-inner,
     .topline {
-        flex-direction: column;
-        align-items: flex-start;
+        padding-left: 16px;
+        padding-right: 16px;
     }
 
     .app-shell__hero-meta {
         width: 100%;
+        min-width: 0;
+    }
+
+    .app-shell__topbar,
+    .app-shell__topbar-main,
+    .app-shell__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .app-shell__session-pill {
+        margin-left: 0;
         min-width: 0;
     }
 

--- a/lifelink-app/public/css/ui-tokens.css
+++ b/lifelink-app/public/css/ui-tokens.css
@@ -1,14 +1,18 @@
 :root {
     --ui-bg: #f8fafb;
+    --ui-bg-canvas: #f3f7fb;
     --ui-bg-soft: #f1f5f9;
     --ui-surface: #ffffff;
     --ui-surface-soft: #f8fbfd;
     --ui-surface-muted: #f4f8fb;
+    --ui-surface-elevated: rgba(255, 255, 255, 0.92);
     --ui-text: #0f172a;
     --ui-text-soft: #1e293b;
     --ui-text-muted: #64748b;
+    --ui-text-faint: #94a3b8;
     --ui-border: #e2e8f0;
     --ui-border-strong: #cbd5e1;
+    --ui-border-soft: rgba(148, 163, 184, 0.2);
     --ui-primary: #0369a1;
     --ui-primary-strong: #075985;
     --ui-primary-soft: #e0f2fe;
@@ -33,12 +37,16 @@
     --ui-shadow-sm: 0 6px 18px rgba(15, 23, 42, 0.06);
     --ui-shadow-md: 0 18px 40px rgba(15, 23, 42, 0.10);
     --ui-shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.14);
+    --ui-shadow-xl: 0 30px 70px rgba(15, 23, 42, 0.12);
     --ui-space-1: 6px;
     --ui-space-2: 10px;
     --ui-space-3: 14px;
     --ui-space-4: 18px;
     --ui-space-5: 24px;
     --ui-space-6: 32px;
+    --ui-space-7: 40px;
+    --ui-shell-max: 1560px;
+    --ui-shell-content-max: 1320px;
     --ui-font-body: "Manrope", "Segoe UI", "Trebuchet MS", sans-serif;
     --ui-font-display: "Sora", "Segoe UI", "Trebuchet MS", sans-serif;
     --ll-space-1: var(--ui-space-1);

--- a/lifelink-app/resources/views/ui/auth.blade.php
+++ b/lifelink-app/resources/views/ui/auth.blade.php
@@ -58,15 +58,15 @@
     <title>LifeLink | {{ $config['title'] }}</title>
     <link rel="stylesheet" href="/css/ui-system.css">
 </head>
-<body>
-    <div class="shell">
-        <header class="topbar">
-            <div class="topbar-inner">
+<body class="auth-page">
+    <div class="shell auth-shell">
+        <header class="topbar topbar--public">
+            <div class="topbar-inner auth-shell__topbar">
                 <div class="brand">
                     <div class="brand-mark">LL</div>
                     <div class="brand-copy">
                         <strong>LifeLink</strong>
-                        <span>{{ $config['title'] }}</span>
+                        <span>Secure access and role-based registration.</span>
                     </div>
                 </div>
                 <nav class="topnav">
@@ -79,7 +79,7 @@
             </div>
         </header>
 
-        <div class="topline">
+        <div class="topline auth-shell__crumbs">
             <div class="crumbs">
                 <a href="/">Public Home</a>
                 <span>/</span>
@@ -88,26 +88,41 @@
             <a class="mini-link" href="/ui/dashboard">Workspace Hub</a>
         </div>
 
-        <section class="layout">
-            <article class="panel hero">
-                <span class="badge">{{ $config['badge'] }}</span>
-                <h1>{{ $config['headline'] }}</h1>
-                <p>{{ $config['copy'] }}</p>
+        <section class="auth-layout">
+            <article class="auth-intro">
+                <div class="auth-intro__panel">
+                    <span class="badge">{{ $config['badge'] }}</span>
+                    <h1>{{ $config['headline'] }}</h1>
+                    <p>{{ $config['copy'] }}</p>
+                    <div class="auth-intro__trust">
+                        <article class="auth-trust-card">
+                            <strong>Single access layer</strong>
+                            <span>One login can route into the correct workspace without changing the current auth behavior.</span>
+                        </article>
+                        <article class="auth-trust-card">
+                            <strong>Dedicated public entry</strong>
+                            <span>Patients, donors, and applicants still keep their own registration journeys.</span>
+                        </article>
+                    </div>
+                </div>
 
-                <div class="path-list">
+                <div class="path-list auth-links">
                     @foreach ($otherLinks as $link)
                         <a class="path-link" href="{{ $link['href'] }}">
                             <strong>{{ $link['label'] }}</strong>
-                            <span>Open</span>
+                            <span>Switch</span>
                         </a>
                     @endforeach
                 </div>
             </article>
 
-            <article class="panel">
+            <article class="auth-card">
                 @if ($mode === 'login')
-                    <h2>Login</h2>
-                    <p>Enter your email and password.</p>
+                    <div class="auth-card__header">
+                        <span class="hub-label">Secure Login</span>
+                        <h2>Sign in</h2>
+                        <p>Enter your email and password to continue.</p>
+                    </div>
 
                     <div class="field">
                         <label for="loginEmail">Email</label>
@@ -123,7 +138,7 @@
                         <button class="button button-secondary" type="button" onclick="useLastEmail()">Use last email</button>
                     </div>
 
-                    <div class="session-card">
+                    <div class="session-card auth-session-card">
                         <strong>Current session</strong>
                         <div class="session-grid">
                             <div><small>User</small><strong id="session-user">No active session</strong></div>
@@ -135,7 +150,7 @@
                         </div>
                     </div>
 
-                    <button class="advanced-toggle" type="button" onclick="toggleAdvanced()">Need bootstrap or setup tools?</button>
+                    <button class="advanced-toggle" type="button" onclick="toggleAdvanced()">Need bootstrap tools?</button>
                     <div id="advanced-card" class="advanced-card">
                         <div class="field">
                             <label for="adminName">Admin full name</label>
@@ -154,8 +169,11 @@
                         </div>
                     </div>
                 @elseif ($mode === 'patient')
-                    <h2>Register as patient</h2>
-                    <p>Create a patient account for appointments, records, and blood requests.</p>
+                    <div class="auth-card__header">
+                        <span class="hub-label">Patient Access</span>
+                        <h2>Create a patient account</h2>
+                        <p>Set up patient access for appointments, records, and blood requests.</p>
+                    </div>
                     <div class="field"><label for="patientName">Full name</label><input id="patientName" type="text" value="Patient UI"></div>
                     <div class="field"><label for="patientEmail">Email</label><input id="patientEmail" type="email" value="patient_ui@demo.com"></div>
                     <div class="field"><label for="patientPassword">Password</label><input id="patientPassword" type="password" value="patient12345"></div>
@@ -176,8 +194,11 @@
                         <a class="ghost-link" href="/ui/login">Already have an account?</a>
                     </div>
                 @elseif ($mode === 'donor')
-                    <h2>Register as blood donor</h2>
-                    <p>Create the account and donor profile.</p>
+                    <div class="auth-card__header">
+                        <span class="hub-label">Donor Access</span>
+                        <h2>Create a donor account</h2>
+                        <p>Create the account first, then continue with donor profile setup.</p>
+                    </div>
                     <div class="field"><label for="donorName">Full name</label><input id="donorName" type="text" value="Donor UI"></div>
                     <div class="field"><label for="donorEmail">Email</label><input id="donorEmail" type="email" value="donor_ui@demo.com"></div>
                     <div class="field"><label for="donorPassword">Password</label><input id="donorPassword" type="password" value="donor12345"></div>
@@ -196,8 +217,11 @@
                         <a class="ghost-link" href="/ui/login">Already have an account?</a>
                     </div>
                 @else
-                    <h2>Register as job applicant</h2>
-                    <p>Create the account and submit the first job application.</p>
+                    <div class="auth-card__header">
+                        <span class="hub-label">Applicant Access</span>
+                        <h2>Create an applicant account</h2>
+                        <p>Create the account, then submit the first job application.</p>
+                    </div>
                     <div class="field"><label for="applicantName">Full name</label><input id="applicantName" type="text" value="Applicant UI"></div>
                     <div class="field"><label for="applicantEmail">Email</label><input id="applicantEmail" type="email" value="applicant_ui@demo.com"></div>
                     <div class="field"><label for="applicantPassword">Password</label><input id="applicantPassword" type="password" value="applicant12345"></div>
@@ -222,7 +246,7 @@
                     </div>
                 @endif
 
-                <div id="message" class="message"></div>
+                <div id="message" class="message auth-message"></div>
             </article>
         </section>
     </div>

--- a/lifelink-app/resources/views/ui/dashboard.blade.php
+++ b/lifelink-app/resources/views/ui/dashboard.blade.php
@@ -6,14 +6,14 @@
     <title>LifeLink | Workspace Hub</title>
     <link rel="stylesheet" href="/css/ui-system.css">
 </head>
-<body>
-    <div class="hub-shell">
+<body class="workspace-page">
+    <div class="hub-shell workspace-shell">
         <header class="hub-topbar">
             <div class="hub-brand">
                 <div class="hub-mark">LL</div>
                 <div>
                     <strong>LifeLink Workspace Hub</strong>
-                    <span>Role-aware routing and operational shortcuts.</span>
+                    <span>Role-aware routing, session context, and operational shortcuts.</span>
                 </div>
             </div>
             <div class="hub-actions">
@@ -27,7 +27,7 @@
                 <article class="hub-block">
                     <span class="hub-label">Signed In</span>
                     <strong id="user-email">No active session</strong>
-                    <p class="hub-copy">Current session.</p>
+                    <p class="hub-copy">Current browser session.</p>
                 </article>
                 <article class="hub-block">
                     <span class="hub-label">Detected Roles</span>
@@ -45,36 +45,40 @@
             </aside>
 
             <main class="hub-main">
-                <section class="hub-block">
-                    <span class="hub-label">Workspace Hub</span>
-                    <h1 id="welcome-line" class="hub-title">Organized access for your role.</h1>
-                    <p id="welcome-copy" class="hub-copy">Open the right workspace and related tools.</p>
+                <section class="workspace-hero">
+                    <article class="hub-block workspace-hero__main">
+                        <span class="hub-label">Workspace Hub</span>
+                        <h1 id="welcome-line" class="hub-title">Organized access for your role.</h1>
+                        <p id="welcome-copy" class="hub-copy">Open the right workspace and related tools.</p>
+                    </article>
+
+                    <article class="hub-block workspace-hero__side">
+                        <span class="hub-label">Session Summary</span>
+                        <div class="hub-stats">
+                            <div class="hub-stat">
+                                <strong id="session-token-state">No token</strong>
+                                <span>Token state</span>
+                            </div>
+                            <div class="hub-stat">
+                                <strong id="session-role-count">0</strong>
+                                <span>Role count</span>
+                            </div>
+                        </div>
+                    </article>
                 </section>
 
-                <section class="hub-block">
-                    <span class="hub-label">Primary Destination</span>
-                    <h2 id="primary-title" class="hub-title">Sign in required</h2>
-                    <p id="primary-copy" class="hub-copy">Log in to unlock role-aware routing.</p>
+                <section class="hub-block workspace-primary">
+                    <div class="workspace-primary__copy">
+                        <span class="hub-label">Primary Destination</span>
+                        <h2 id="primary-title" class="hub-title">Sign in required</h2>
+                        <p id="primary-copy" class="hub-copy">Log in to unlock role-aware routing.</p>
+                    </div>
                     <div class="hub-actions u-mt-2">
                         <a id="primary-link" class="hub-primary" href="/ui/login">Open login page</a>
                     </div>
                 </section>
 
-                <section class="hub-block">
-                    <span class="hub-label">Session Snapshot</span>
-                    <div class="hub-stats">
-                        <div class="hub-stat">
-                            <strong id="session-token-state">No token</strong>
-                            <span>Token state</span>
-                        </div>
-                        <div class="hub-stat">
-                            <strong id="session-role-count">0</strong>
-                            <span>Role count</span>
-                        </div>
-                    </div>
-                </section>
-
-                <section class="hub-block">
+                <section class="hub-block workspace-shortcuts">
                     <span class="hub-label">Role Shortcuts</span>
                     <div id="action-grid" class="hub-grid"></div>
                 </section>

--- a/lifelink-app/resources/views/ui/it-bed-allocation.blade.php
+++ b/lifelink-app/resources/views/ui/it-bed-allocation.blade.php
@@ -70,7 +70,6 @@
                 <div class="it-stat"><small>Blood Bank access</small><strong id="bloodBankScopeStatus">Locked</strong></div>
                 <div class="it-stat"><small>Blood Bank departments</small><strong id="bloodBankScopeCount">0</strong></div>
             </div>
-            <div id="itBloodBankDebugMarker" class="ll-debug-marker" hidden>DEBUG: Blood Bank IT inline workspace mounted</div>
             <div class="bbops-grid u-mt-4">
                 <div class="bbops-summary">
                     <div class="it-stat"><small>Requests shown</small><strong id="bbRequestCount">0</strong></div>
@@ -705,11 +704,6 @@ function setActivePanel(panelId) {
     }
 
     state.activePanel = panelId;
-    console.log('[ItDashboard] active panel selected', {
-        activePanel: panelId,
-        allowedPanels: allowed,
-        hash: window.location.hash || '',
-    });
 
     itPanelIds.forEach((id) => {
         const panel = document.getElementById(id);
@@ -860,7 +854,6 @@ function renderDepartmentMode() {
     const bloodBankVisible = bloodBankAccess && selectedPanel === 'it-blood-bank';
     const regularWorkspaceVisible = regularAccess && selectedPanel !== 'it-blood-bank';
     setVisibility('it-blood-bank', bloodBankVisible, 'block');
-    setVisibility('itBloodBankDebugMarker', bloodBankVisible, 'block');
     setVisibility('standardItWorkArea', regularWorkspaceVisible, 'block');
     setVisibility('regularItLocked', !regularAccess && selectedPanel !== 'it-blood-bank', 'block');
     document.getElementById('bloodBankScopeStatus').textContent = bloodBankAccess ? 'Enabled' : 'Locked';
@@ -877,16 +870,6 @@ function renderDepartmentMode() {
         : bloodBankAccess
                 ? 'Blood Bank IT mode is active for this account.'
                 : 'Regular IT mode is active for this account.';
-    console.log('[ItDashboard] scope decision', {
-        scopeLoaded: state.scopeLoaded,
-        departments: state.scopeDepartments.map((department) => department.dept_name || department.department || department),
-        bloodBankAccess,
-        regularAccess,
-        selectedPanel,
-        bloodBankSectionShown: bloodBankVisible,
-        regularWorkspaceShown: regularWorkspaceVisible,
-    });
-    console.log('[ItDashboard] Blood Bank section visibility', bloodBankVisible ? 'shown' : 'hidden');
     updateSidebarByScope();
 }
 

--- a/lifelink-app/resources/views/ui/layouts/app.blade.php
+++ b/lifelink-app/resources/views/ui/layouts/app.blade.php
@@ -10,15 +10,25 @@
 <body>
     <div class="app-shell">
         <header class="app-shell__topbar">
-            <a class="app-shell__brand" href="/">
-                <div class="app-shell__mark">LL</div>
-                <div>
-                    <strong>LifeLink Workspace</strong>
-                    @if(trim($__env->yieldContent('workspace_label', 'Role-aware authenticated mode')) !== '')
-                        <span>@yield('workspace_label', 'Role-aware authenticated mode')</span>
-                    @endif
+            <div class="app-shell__topbar-main">
+                <a class="app-shell__brand" href="/">
+                    <div class="app-shell__mark">LL</div>
+                    <div class="app-shell__brand-copy">
+                        <strong>LifeLink Workspace</strong>
+                        @if(trim($__env->yieldContent('workspace_label', 'Role-aware authenticated mode')) !== '')
+                            <span>@yield('workspace_label', 'Role-aware authenticated mode')</span>
+                        @else
+                            <span>Authenticated care operations</span>
+                        @endif
+                    </div>
+                </a>
+
+                <div class="app-shell__session-pill" aria-live="polite">
+                    <span class="app-shell__session-label">Active session</span>
+                    <strong id="shell-topbar-user">No active session</strong>
+                    <span id="shell-topbar-role">No role detected</span>
                 </div>
-            </a>
+            </div>
 
             <div class="app-shell__actions">
                 <a class="app-shell__chip" href="/">Public Home</a>
@@ -40,12 +50,14 @@
                     <p>@yield('hero_description', 'This area is part of the authenticated product flow.')</p>
                 @endif
                 @hasSection('hero_extra')
-                    @yield('hero_extra')
+                    <div class="app-shell__hero-extra">
+                        @yield('hero_extra')
+                    </div>
                 @endif
             </div>
 
             <div class="app-shell__hero-meta">
-                <div class="app-shell__meta-card">
+                <div class="app-shell__meta-card app-shell__meta-card--identity">
                     <small>Signed in as</small>
                     <strong id="shell-user-name">No active session</strong>
                     <span id="shell-user-meta">No role detected</span>
@@ -62,7 +74,11 @@
 
         <section class="app-shell__body">
             <aside class="app-shell__sidebar">
-                <nav class="app-shell__nav">
+                <div class="app-shell__sidebar-head">
+                    <span class="app-shell__sidebar-eyebrow">Workspace navigation</span>
+                    <p class="app-shell__sidebar-copy">Move between role-aware sections without leaving the current authenticated flow.</p>
+                </div>
+                <nav class="app-shell__nav" aria-label="Workspace sections">
                     @yield('sidebar_nav')
                 </nav>
                 @yield('sidebar')
@@ -74,7 +90,7 @@
                         @yield('section_nav')
                     </div>
                 @endif
-                <div class="app-shell__content-body">
+                <div class="app-shell__content-body ui-card ui-card--shell">
                     @yield('content')
                 </div>
             </main>
@@ -114,6 +130,8 @@
         const roles = JSON.parse(localStorage.getItem('CURRENT_USER_ROLES') || '[]');
         const userName = document.getElementById('shell-user-name');
         const userMeta = document.getElementById('shell-user-meta');
+        const topbarUser = document.getElementById('shell-topbar-user');
+        const topbarRole = document.getElementById('shell-topbar-role');
         const preferredRole = window.lifeLinkShell.getPreferredRole(roles);
         const identity = fullName || email;
         const metaParts = [];
@@ -124,6 +142,8 @@
 
         if (userName) userName.textContent = identity;
         if (userMeta) userMeta.textContent = metaParts.join(' | ');
+        if (topbarUser) topbarUser.textContent = identity;
+        if (topbarRole) topbarRole.textContent = preferredRole ? `${preferredRole} workflow` : 'No role detected';
     })();
     </script>
     @stack('scripts')

--- a/lifelink-app/resources/views/ui/nurse-dashboard.blade.php
+++ b/lifelink-app/resources/views/ui/nurse-dashboard.blade.php
@@ -193,7 +193,6 @@
 
             <div id="bloodBankLocked" class="nurse-note">Load your nurse profile first to see whether Blood Bank donor screening is available for this account.</div>
             <div id="bloodBankSection" hidden>
-                <div id="bloodBankDebugMarker" class="ll-debug-marker" hidden>DEBUG: Blood Bank nurse real panel mounted</div>
                 <div class="nurse-summary-grid">
                     <div class="nurse-summary"><small>Step 1</small><strong>Search and select donor</strong></div>
                     <div class="nurse-summary"><small>Step 2</small><strong>Review latest screening history</strong></div>
@@ -421,11 +420,6 @@ function setActivePanel(panelId) {
     }
 
     state.activePanel = panelId;
-    console.log('[NurseDashboard] active panel selected', {
-        activePanel: panelId,
-        allowedPanels: allowed,
-        hash: window.location.hash || '',
-    });
 
     nursePanelIds.forEach((id) => {
         const panel = document.getElementById(id);
@@ -642,7 +636,6 @@ function renderBloodBankAccess() {
     setVisibility('regularNurseWorkArea', hasRegularMode, 'grid');
     setVisibility('bloodBankLocked', !bloodBankVisible, 'block');
     setVisibility('bloodBankSection', bloodBankVisible, 'block');
-    setVisibility('bloodBankDebugMarker', bloodBankVisible, 'block');
     regularLockedMessage.textContent = !profileLoaded
         ? 'Load your nurse profile to open the correct workflow.'
         : isBloodBank
@@ -656,14 +649,6 @@ function renderBloodBankAccess() {
         : isBloodBank
             ? 'Blood Bank nurse mode is active for this account.'
             : `Regular nurse mode is active for ${state.nurse?.department || 'this department'}.`;
-    console.log('[NurseDashboard] mode decision', {
-        profileLoaded,
-        department: state.nurse?.department || state.nurse?.department_name || state.nurse?.dept_name || null,
-        isBloodBank,
-        bloodBankSectionShown: bloodBankVisible,
-        regularSectionShown: hasRegularMode,
-    });
-    console.log('[NurseDashboard] Blood Bank section visibility', bloodBankVisible ? 'shown' : 'hidden');
     updateNurseSidebarByMode();
 }
 

--- a/lifelink-app/resources/views/welcome.blade.php
+++ b/lifelink-app/resources/views/welcome.blade.php
@@ -6,51 +6,90 @@
     <title>LifeLink | Modern Hospital Management</title>
     <link rel="stylesheet" href="/css/ui-system.css">
 </head>
-<body>
-    <header class="topbar">
+<body class="welcome-page">
+    <header class="topbar topbar--public">
         <div class="shell topbar-inner">
             <div class="brand">
                 <div class="brand-mark">LL</div>
                 <div class="brand-copy">
                     <strong>LifeLink</strong>
-                    <span>Hospital coordination for care, beds, and blood response.</span>
+                    <span>Modern hospital operations, patient access, and blood response.</span>
                 </div>
             </div>
 
             <nav class="topnav">
                 <a href="#overview">Overview</a>
-                <a href="#modules">Services</a>
+                <a href="#find-department">Department Finder</a>
+                <a href="#modules">Platform</a>
                 <a href="#entry">Entry</a>
                 <a id="auth-nav-link" href="/ui/login">Login / Register</a>
-                <a id="session-nav-link" class="cta" href="/ui">Explore UI</a>
+                <a id="session-nav-link" class="cta" href="/ui">Workspace</a>
             </nav>
         </div>
     </header>
 
     <div class="shell">
-        <main>
-            <section class="hero" id="overview">
-                <article>
-                    <span class="badge">Public Mode</span>
-                    <h1>One platform for hospital operations and donor response.</h1>
-                    <p>LifeLink connects admissions, bed allocation, patient access, and blood-request workflows in one role-aware system.</p>
+        <main class="welcome-main">
+            <section class="welcome-hero" id="overview">
+                <article class="welcome-hero__copy">
+                    <span class="badge">Healthcare SaaS</span>
+                    <h1>Coordinate hospital care, access, and blood operations from one calm system.</h1>
+                    <p>LifeLink brings together admissions, bed management, patient-facing access, staff workspaces, and Blood Bank response in a single role-aware experience.</p>
                     <div class="hero-actions">
                         <a class="button primary" href="/ui/login">Open Login</a>
-                        <a class="button" href="#modules">See Modules</a>
-                        <a class="button" href="/ui/dashboard">Workspace Hub</a>
+                        <a class="button" href="#find-department">Find a Department</a>
+                        <a class="button" href="/ui/dashboard">Open Workspace Hub</a>
+                    </div>
+                    <div class="welcome-proof">
+                        <div class="welcome-proof__item">
+                            <strong>Role-aware entry</strong>
+                            <span>Launch the right workspace without changing the existing routing or session behavior.</span>
+                        </div>
+                        <div class="welcome-proof__item">
+                            <strong>Operational coverage</strong>
+                            <span>Admissions, clinical coordination, and Blood Bank workflows stay connected in one product surface.</span>
+                        </div>
                     </div>
                 </article>
-                <aside class="meta">
-                    <strong>Connected workflows</strong>
-                    <p>Admissions, bedside care, donor coordination, and blood response in one system.</p>
+                <aside class="welcome-hero__aside">
+                    <article class="welcome-highlight">
+                        <span class="welcome-highlight__label">Deployment-ready feel</span>
+                        <strong>Built for patients, clinicians, operations, and donor-response teams.</strong>
+                        <p>Calmer hierarchy, stronger cards, and cleaner entry points make LifeLink feel intentional from the first screen.</p>
+                    </article>
+                    <div class="welcome-metrics">
+                        <article class="welcome-metric">
+                            <strong>7</strong>
+                            <span>Role paths</span>
+                        </article>
+                        <article class="welcome-metric">
+                            <strong>1</strong>
+                            <span>Unified workspace system</span>
+                        </article>
+                        <article class="welcome-metric">
+                            <strong>24/7</strong>
+                            <span>Operational posture</span>
+                        </article>
+                    </div>
                 </aside>
+            </section>
+
+            <section class="welcome-bands" aria-label="LifeLink strengths">
+                <article class="welcome-band">
+                    <span class="hub-label">Operational Core</span>
+                    <h2>Trusted structure for admissions, clinical work, and donor response.</h2>
+                </article>
+                <article class="welcome-band">
+                    <span class="hub-label">Session-aware Entry</span>
+                    <p>Signed-out visitors can move into login or registration, while active sessions can continue directly into the right dashboard.</p>
+                </article>
             </section>
 
             <section class="finder-section" id="find-department" aria-labelledby="finder-title">
                 <div class="finder-header">
-                    <span class="badge">Guided Discovery</span>
+                    <span class="badge">Department Finder</span>
                     <h2 id="finder-title">Find the right department</h2>
-                    <p>Use the body map to identify the most relevant department path.</p>
+                    <p>Use the anatomy guide to surface the most relevant department path before you continue into LifeLink.</p>
                 </div>
 
                 <div class="finder-shell">
@@ -132,30 +171,35 @@
 
                         <div class="hero-actions">
                             <a class="button primary" href="/ui/login">Continue to Login</a>
+                            <a class="button" href="#entry">See account entry</a>
                         </div>
                     </aside>
                 </div>
             </section>
 
-            <section id="modules" class="grid">
-                <article class="card">
+            <section id="modules" class="welcome-module-grid">
+                <article class="card welcome-module-card">
+                    <span class="hub-label">Identity</span>
                     <h2>Role-aware authentication</h2>
-                    <p>Single login entry with route decisions based on active role.</p>
+                    <p>One entry layer for patients, staff, donors, and applicants with workspace routing that stays tied to current roles.</p>
                 </article>
-                <article class="card">
+                <article class="card welcome-module-card">
+                    <span class="hub-label">Operations</span>
                     <h2>Admissions and beds</h2>
-                    <p>Department scope, care units, admissions, and bed assignment.</p>
+                    <p>Department scope, care units, patient movement, and bed allocation live inside the same operational surface.</p>
                 </article>
-                <article class="card">
+                <article class="card welcome-module-card">
+                    <span class="hub-label">Blood Bank</span>
                     <h2>Blood operations</h2>
-                    <p>Donor readiness, matching, notifications, and fulfillment flow.</p>
+                    <p>Donor screening, matching, notifications, approval, fulfillment, and donation logging stay connected end to end.</p>
                 </article>
             </section>
 
-            <section id="entry" class="auth-grid">
-                <div id="logged-out-entry" class="card stack">
-                    <h2>Account entry</h2>
-                    <p>Login for existing users, or create a patient, donor, or applicant account.</p>
+            <section id="entry" class="welcome-entry-grid">
+                <div id="logged-out-entry" class="card stack welcome-entry-card">
+                    <span class="hub-label">Account Entry</span>
+                    <h2>Choose the right way into LifeLink.</h2>
+                    <p>Sign in to an existing account or create the right public entry for patients, donors, and staff applicants.</p>
                     <div class="hero-actions">
                         <a class="button primary" href="/ui/login">Login</a>
                         <a class="button" href="/ui/register/patient">Patient Register</a>
@@ -164,12 +208,22 @@
                     </div>
                 </div>
 
-                <div id="logged-in-entry" class="card stack page-hidden">
-                    <h2>Session detected</h2>
-                    <p>Continue to your workspace or sign out before switching account.</p>
+                <div id="logged-in-entry" class="card stack welcome-entry-card page-hidden">
+                    <span class="hub-label">Active Session</span>
+                    <h2>Continue into your workspace.</h2>
+                    <p>A session is already available in this browser. Move forward or sign out before switching accounts.</p>
                     <div class="hero-actions">
                         <a id="logged-dashboard-link" class="button primary" href="/ui/dashboard">Go to dashboard</a>
                         <button id="logout-button" class="button" type="button">Logout</button>
+                    </div>
+                </div>
+
+                <div class="card stack welcome-entry-card welcome-entry-card--support">
+                    <span class="hub-label">Care Access</span>
+                    <h2>Need help choosing a route?</h2>
+                    <p>Use the department finder for symptom-based guidance, then enter through the login or registration path that fits your role.</p>
+                    <div class="hero-actions">
+                        <a class="button" href="#find-department">Open anatomy guide</a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
- rebuild welcome page with stronger hero, premium anatomy finder, and clearer entry cards\n- redesign auth page as cleaner gateway with trust/intro rail and focused auth card\n- upgrade dashboard workspace hub with hero summary and stronger primary destination\n- add new CSS files: ui-layout.css for page-level layout patterns\n- extend ui-components.css with proof cards, trust cards, metrics, and entry cards\n- enhance ui-dashboard.css with workspace-hub polish\n- preserve all existing functionality including anatomy finder hotspots, API calls, role-aware routing, and redirect behavior\n- maintain session-aware actions and Blood Bank IT shortcuts\n- reduce prototype-like tone and replace with product-facing copy